### PR TITLE
feat: add debug agent

### DIFF
--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -12,3 +12,6 @@ clap = { version = "4.5.4", features = ["derive"] }
 rand = "0.8.5"
 serde = { version = "1.0.197", features = ["derive"] }
 toml = "0.8.12"
+
+[features]
+debug-agent = []

--- a/src/agent/src/agents/debug.rs
+++ b/src/agent/src/agents/debug.rs
@@ -30,7 +30,7 @@ impl Agent for DebugAgent {
                 SystemTime::now(),
             ),
         )
-            .expect("Unable to write debug.txt file");
+        .expect("Unable to write debug.txt file");
 
         Ok(AgentOutput {
             exit_code: 0,

--- a/src/agent/src/agents/debug.rs
+++ b/src/agent/src/agents/debug.rs
@@ -1,0 +1,56 @@
+use super::AgentOutput;
+use crate::agents::Agent;
+use crate::{workload, AgentResult};
+use std::fs::create_dir_all;
+use std::time::SystemTime;
+
+pub struct DebugAgent {
+    workload_config: workload::config::Config,
+}
+
+impl From<workload::config::Config> for DebugAgent {
+    fn from(workload_config: workload::config::Config) -> Self {
+        Self { workload_config }
+    }
+}
+
+impl Agent for DebugAgent {
+    fn prepare(&self) -> AgentResult<AgentOutput> {
+        let dir = format!("/tmp/{}", self.workload_config.workload_name);
+
+        println!("Function directory: {}", dir);
+
+        create_dir_all(&dir).expect("Unable to create directory");
+
+        std::fs::write(
+            format!("{}/debug.txt", &dir),
+            format!(
+                "Debug agent for {} - written at {:?}",
+                self.workload_config.workload_name,
+                SystemTime::now(),
+            ),
+        )
+            .expect("Unable to write debug.txt file");
+
+        Ok(AgentOutput {
+            exit_code: 0,
+            stdout: "Build successfully!".into(),
+            stderr: String::default(),
+        })
+    }
+
+    fn run(&self) -> AgentResult<AgentOutput> {
+        let dir = format!("/tmp/{}", self.workload_config.workload_name);
+
+        let content = std::fs::read_to_string(format!("{}/debug.txt", &dir))
+            .expect("Unable to read debug.txt file");
+
+        std::fs::remove_dir_all(dir).expect("Unable to remove directory");
+
+        Ok(AgentOutput {
+            exit_code: 0,
+            stdout: content,
+            stderr: String::default(),
+        })
+    }
+}

--- a/src/agent/src/agents/mod.rs
+++ b/src/agent/src/agents/mod.rs
@@ -1,6 +1,8 @@
 use crate::AgentResult;
 use serde::Deserialize;
 
+#[cfg(feature = "debug-agent")]
+pub mod debug;
 pub mod rust;
 
 #[derive(Debug, Clone)]
@@ -19,12 +21,16 @@ pub trait Agent {
 #[serde(rename_all = "kebab-case")]
 pub enum Language {
     Rust,
+    #[cfg(feature = "debug-agent")]
+    Debug,
 }
 
 impl std::fmt::Display for Language {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Language::Rust => write!(f, "rust"),
+            #[cfg(feature = "debug-agent")]
+            Language::Debug => write!(f, "debug"),
         }
     }
 }

--- a/src/agent/src/workload/runner.rs
+++ b/src/agent/src/workload/runner.rs
@@ -4,6 +4,9 @@ use crate::{
     AgentResult,
 };
 
+#[cfg(feature = "debug-agent")]
+use crate::agents::debug;
+
 /// Runner for a workload.  
 /// Will execute the workload based on the inner agent (language).
 pub struct Runner {
@@ -15,6 +18,8 @@ impl Runner {
     pub fn new(config: Config) -> Self {
         let agent: Box<dyn Agent> = match config.language {
             Language::Rust => Box::new(rust::RustAgent::from(config.clone())),
+            #[cfg(feature = "debug-agent")]
+            Language::Debug => Box::new(debug::DebugAgent::from(config.clone())),
         };
 
         Runner { config, agent }


### PR DESCRIPTION
This draft PR implement a mock agent.
At the end, a new file will be created at `/tmp/<workload_name>` during preparation and populated with some values.
This file will be read during run, and its content will be outputed to stdout.